### PR TITLE
Added functionality to check registered team (fixes #1)

### DIFF
--- a/index.php
+++ b/index.php
@@ -6,266 +6,290 @@ session_start();
 ?>
 <!DOCTYPE html>
 <html lang='en'>
+
 <head>
-<title>FAL Registration</title>
-<meta charset='utf-8'>
-<link rel="shortcut icon" type="image/x-icon" href="favicon.png">
-<meta name='viewport' content='width=device-width, initial-scale=1'>
-<link rel='stylesheet' href='https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css'>
-<script src='https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js'></script>
-<script src='https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js'></script>
-<script type='text/javascript' src='reg.js'></script>
+    <title>FAL Registration</title>
+    <meta charset='utf-8'>
+    <link rel="shortcut icon" type="image/x-icon" href="favicon.png">
+    <meta name='viewport' content='width=device-width, initial-scale=1'>
+    <link rel='stylesheet' href='https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css'>
+    <script src='https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js'></script>
+    <script src='https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js'></script>
+    <script type='text/javascript' src='reg.js'></script>
 </head>
+
 <body style='margin-bottom:150px'>
-<!--
-<h1 class='text-center' id='title'>FAL Registration</h1>
-<br>
-<div id='main' class='container-fluid'>
-	
-<div class='col-md-offset-3 col-md-6 col-lg-offset-4 col-lg-4 col-xl-offset-5 col-xl-2'>
-<label>Your MAL Username:</label>
-<input type='text' class='form-control' id='username_input' placeholder='Username'><br>
-<button class='btn btn-info btn-block' id='code_btn'>Continue</button><br>
-<br>
-<div id='selections_div' style='display:none'>
-<h3>Select your team:</h3>
-<br>
-<label>Active Show #1</label><br />
-<select class='form-control' id="0">
-<option value='39337'>Araiya-san!: Ore to Aitsu ga Onnayu de!?</option>
-<option value='38860'>Bakumatsu: Crisis</option>
-<option value='38186'>Bokutachi wa Benkyou ga Dekinai</option>
-<option value='37435'>Carole & Tuesday</option>
-<option value='38226'>Chou Kadou Girl ⅙: Amazing Stranger</option>
-<option value='38731'>Diamond no Ace: Act II</option>
-<option value='39063'>Fairy Gone</option>
-<option value='37806'>Gunjou no Magmel</option>
-<option value='38091'>Hachigatsu no Cinderella Nine</option>
-<option value='38268'>Hangyakusei Million Arthur 2nd Season</option>
-<option value='37614'>Hitoribocchi no 笳銀雷 Seikatsu</option>
-<option value='38295'>Joshikausei</option>
-<option value='36407'>Kenja no Mago</option>
-<option value='38000'>Kimetsu no Yaiba</option>
-<option value='38080'>Kono Oto Tomare!</option>
-<option value='34620'>Kono Yo no Hate de Koi wo Utau Shoujo YU-NO</option>
-<option value='37964'>Mayonaka no Occult Koumuin</option>
-<option value='38778'>Midara na Ao-chan wa Benkyou ga Dekinai</option>
-<option value='38098'>Mix: Meisei Story</option>
-<option value='38150'>Namu Amida Butsu!: Rendai Utena</option>
-<option value='38397'>Nande Koko ni Sensei ga!?</option>
-<option value='38814'>Nobunaga-sensei no Osanazuma</option>
-<option value='38707'>RobiHachi</option>
-<option value='37426'>Sarazanmai</option>
-<option value='38787'>Senryuu Shoujo</option>
-<option value='38759'>Sewayaki Kitsune no Senko-san</option>
-<option value='37952'>Shoumetsu Toshi</option>
-<option value='38004'>World Witches Series: 501-butai Hasshin Shimasu!</option>
-<option value='37940'>Yatogame-chan Kansatsu Nikki</option>
-</select><br />
-<label>Active Show #2</label><br />
-<select class='form-control' id="1">
-<option value='39337'>Araiya-san!: Ore to Aitsu ga Onnayu de!?</option>
-<option value='38860'>Bakumatsu: Crisis</option>
-<option value='38186'>Bokutachi wa Benkyou ga Dekinai</option>
-<option value='37435'>Carole & Tuesday</option>
-<option value='38226'>Chou Kadou Girl ⅙: Amazing Stranger</option>
-<option value='38731'>Diamond no Ace: Act II</option>
-<option value='39063'>Fairy Gone</option>
-<option value='37806'>Gunjou no Magmel</option>
-<option value='38091'>Hachigatsu no Cinderella Nine</option>
-<option value='38268'>Hangyakusei Million Arthur 2nd Season</option>
-<option value='37614'>Hitoribocchi no 笳銀雷 Seikatsu</option>
-<option value='38295'>Joshikausei</option>
-<option value='36407'>Kenja no Mago</option>
-<option value='38000'>Kimetsu no Yaiba</option>
-<option value='38080'>Kono Oto Tomare!</option>
-<option value='34620'>Kono Yo no Hate de Koi wo Utau Shoujo YU-NO</option>
-<option value='37964'>Mayonaka no Occult Koumuin</option>
-<option value='38778'>Midara na Ao-chan wa Benkyou ga Dekinai</option>
-<option value='38098'>Mix: Meisei Story</option>
-<option value='38150'>Namu Amida Butsu!: Rendai Utena</option>
-<option value='38397'>Nande Koko ni Sensei ga!?</option>
-<option value='38814'>Nobunaga-sensei no Osanazuma</option>
-<option value='38707'>RobiHachi</option>
-<option value='37426'>Sarazanmai</option>
-<option value='38787'>Senryuu Shoujo</option>
-<option value='38759'>Sewayaki Kitsune no Senko-san</option>
-<option value='37952'>Shoumetsu Toshi</option>
-<option value='38004'>World Witches Series: 501-butai Hasshin Shimasu!</option>
-<option value='37940'>Yatogame-chan Kansatsu Nikki</option>
-</select><br />
-<label>Active Show #3</label><br />
-<select class='form-control' id="2">
-<option value='39337'>Araiya-san!: Ore to Aitsu ga Onnayu de!?</option>
-<option value='38860'>Bakumatsu: Crisis</option>
-<option value='38186'>Bokutachi wa Benkyou ga Dekinai</option>
-<option value='37435'>Carole & Tuesday</option>
-<option value='38226'>Chou Kadou Girl ⅙: Amazing Stranger</option>
-<option value='38731'>Diamond no Ace: Act II</option>
-<option value='39063'>Fairy Gone</option>
-<option value='37806'>Gunjou no Magmel</option>
-<option value='38091'>Hachigatsu no Cinderella Nine</option>
-<option value='38268'>Hangyakusei Million Arthur 2nd Season</option>
-<option value='37614'>Hitoribocchi no 笳銀雷 Seikatsu</option>
-<option value='38295'>Joshikausei</option>
-<option value='36407'>Kenja no Mago</option>
-<option value='38000'>Kimetsu no Yaiba</option>
-<option value='38080'>Kono Oto Tomare!</option>
-<option value='34620'>Kono Yo no Hate de Koi wo Utau Shoujo YU-NO</option>
-<option value='37964'>Mayonaka no Occult Koumuin</option>
-<option value='38778'>Midara na Ao-chan wa Benkyou ga Dekinai</option>
-<option value='38098'>Mix: Meisei Story</option>
-<option value='38150'>Namu Amida Butsu!: Rendai Utena</option>
-<option value='38397'>Nande Koko ni Sensei ga!?</option>
-<option value='38814'>Nobunaga-sensei no Osanazuma</option>
-<option value='38707'>RobiHachi</option>
-<option value='37426'>Sarazanmai</option>
-<option value='38787'>Senryuu Shoujo</option>
-<option value='38759'>Sewayaki Kitsune no Senko-san</option>
-<option value='37952'>Shoumetsu Toshi</option>
-<option value='38004'>World Witches Series: 501-butai Hasshin Shimasu!</option>
-<option value='37940'>Yatogame-chan Kansatsu Nikki</option>
-</select><br />
-<label>Active Show #4</label><br />
-<select class='form-control' id="3">
-<option value='39337'>Araiya-san!: Ore to Aitsu ga Onnayu de!?</option>
-<option value='38860'>Bakumatsu: Crisis</option>
-<option value='38186'>Bokutachi wa Benkyou ga Dekinai</option>
-<option value='37435'>Carole & Tuesday</option>
-<option value='38226'>Chou Kadou Girl ⅙: Amazing Stranger</option>
-<option value='38731'>Diamond no Ace: Act II</option>
-<option value='39063'>Fairy Gone</option>
-<option value='37806'>Gunjou no Magmel</option>
-<option value='38091'>Hachigatsu no Cinderella Nine</option>
-<option value='38268'>Hangyakusei Million Arthur 2nd Season</option>
-<option value='37614'>Hitoribocchi no 笳銀雷 Seikatsu</option>
-<option value='38295'>Joshikausei</option>
-<option value='36407'>Kenja no Mago</option>
-<option value='38000'>Kimetsu no Yaiba</option>
-<option value='38080'>Kono Oto Tomare!</option>
-<option value='34620'>Kono Yo no Hate de Koi wo Utau Shoujo YU-NO</option>
-<option value='37964'>Mayonaka no Occult Koumuin</option>
-<option value='38778'>Midara na Ao-chan wa Benkyou ga Dekinai</option>
-<option value='38098'>Mix: Meisei Story</option>
-<option value='38150'>Namu Amida Butsu!: Rendai Utena</option>
-<option value='38397'>Nande Koko ni Sensei ga!?</option>
-<option value='38814'>Nobunaga-sensei no Osanazuma</option>
-<option value='38707'>RobiHachi</option>
-<option value='37426'>Sarazanmai</option>
-<option value='38787'>Senryuu Shoujo</option>
-<option value='38759'>Sewayaki Kitsune no Senko-san</option>
-<option value='37952'>Shoumetsu Toshi</option>
-<option value='38004'>World Witches Series: 501-butai Hasshin Shimasu!</option>
-<option value='37940'>Yatogame-chan Kansatsu Nikki</option>
-</select><br />
-<label>Active Show #5</label><br />
-<select class='form-control' id="4">
-<option value='39337'>Araiya-san!: Ore to Aitsu ga Onnayu de!?</option>
-<option value='38860'>Bakumatsu: Crisis</option>
-<option value='38186'>Bokutachi wa Benkyou ga Dekinai</option>
-<option value='37435'>Carole & Tuesday</option>
-<option value='38226'>Chou Kadou Girl ⅙: Amazing Stranger</option>
-<option value='38731'>Diamond no Ace: Act II</option>
-<option value='39063'>Fairy Gone</option>
-<option value='37806'>Gunjou no Magmel</option>
-<option value='38091'>Hachigatsu no Cinderella Nine</option>
-<option value='38268'>Hangyakusei Million Arthur 2nd Season</option>
-<option value='37614'>Hitoribocchi no 笳銀雷 Seikatsu</option>
-<option value='38295'>Joshikausei</option>
-<option value='36407'>Kenja no Mago</option>
-<option value='38000'>Kimetsu no Yaiba</option>
-<option value='38080'>Kono Oto Tomare!</option>
-<option value='34620'>Kono Yo no Hate de Koi wo Utau Shoujo YU-NO</option>
-<option value='37964'>Mayonaka no Occult Koumuin</option>
-<option value='38778'>Midara na Ao-chan wa Benkyou ga Dekinai</option>
-<option value='38098'>Mix: Meisei Story</option>
-<option value='38150'>Namu Amida Butsu!: Rendai Utena</option>
-<option value='38397'>Nande Koko ni Sensei ga!?</option>
-<option value='38814'>Nobunaga-sensei no Osanazuma</option>
-<option value='38707'>RobiHachi</option>
-<option value='37426'>Sarazanmai</option>
-<option value='38787'>Senryuu Shoujo</option>
-<option value='38759'>Sewayaki Kitsune no Senko-san</option>
-<option value='37952'>Shoumetsu Toshi</option>
-<option value='38004'>World Witches Series: 501-butai Hasshin Shimasu!</option>
-<option value='37940'>Yatogame-chan Kansatsu Nikki</option>
-</select>
-<br><br>
-<label>Bench Show #1</label><br />
-<select class='form-control' id="5">
-<option value='39337'>Araiya-san!: Ore to Aitsu ga Onnayu de!?</option>
-<option value='38860'>Bakumatsu: Crisis</option>
-<option value='38186'>Bokutachi wa Benkyou ga Dekinai</option>
-<option value='37435'>Carole & Tuesday</option>
-<option value='38226'>Chou Kadou Girl ⅙: Amazing Stranger</option>
-<option value='38731'>Diamond no Ace: Act II</option>
-<option value='39063'>Fairy Gone</option>
-<option value='37806'>Gunjou no Magmel</option>
-<option value='38091'>Hachigatsu no Cinderella Nine</option>
-<option value='38268'>Hangyakusei Million Arthur 2nd Season</option>
-<option value='37614'>Hitoribocchi no 笳銀雷 Seikatsu</option>
-<option value='38295'>Joshikausei</option>
-<option value='36407'>Kenja no Mago</option>
-<option value='38000'>Kimetsu no Yaiba</option>
-<option value='38080'>Kono Oto Tomare!</option>
-<option value='34620'>Kono Yo no Hate de Koi wo Utau Shoujo YU-NO</option>
-<option value='37964'>Mayonaka no Occult Koumuin</option>
-<option value='38778'>Midara na Ao-chan wa Benkyou ga Dekinai</option>
-<option value='38098'>Mix: Meisei Story</option>
-<option value='38150'>Namu Amida Butsu!: Rendai Utena</option>
-<option value='38397'>Nande Koko ni Sensei ga!?</option>
-<option value='38814'>Nobunaga-sensei no Osanazuma</option>
-<option value='38707'>RobiHachi</option>
-<option value='37426'>Sarazanmai</option>
-<option value='38787'>Senryuu Shoujo</option>
-<option value='38759'>Sewayaki Kitsune no Senko-san</option>
-<option value='37952'>Shoumetsu Toshi</option>
-<option value='38004'>World Witches Series: 501-butai Hasshin Shimasu!</option>
-<option value='37940'>Yatogame-chan Kansatsu Nikki</option>
-</select><br />
-<label>Bench Show #2</label><br />
-<select class='form-control' id="6">
-<option value='39337'>Araiya-san!: Ore to Aitsu ga Onnayu de!?</option>
-<option value='38860'>Bakumatsu: Crisis</option>
-<option value='38186'>Bokutachi wa Benkyou ga Dekinai</option>
-<option value='37435'>Carole & Tuesday</option>
-<option value='38226'>Chou Kadou Girl ⅙: Amazing Stranger</option>
-<option value='38731'>Diamond no Ace: Act II</option>
-<option value='39063'>Fairy Gone</option>
-<option value='37806'>Gunjou no Magmel</option>
-<option value='38091'>Hachigatsu no Cinderella Nine</option>
-<option value='38268'>Hangyakusei Million Arthur 2nd Season</option>
-<option value='37614'>Hitoribocchi no 笳銀雷 Seikatsu</option>
-<option value='38295'>Joshikausei</option>
-<option value='36407'>Kenja no Mago</option>
-<option value='38000'>Kimetsu no Yaiba</option>
-<option value='38080'>Kono Oto Tomare!</option>
-<option value='34620'>Kono Yo no Hate de Koi wo Utau Shoujo YU-NO</option>
-<option value='37964'>Mayonaka no Occult Koumuin</option>
-<option value='38778'>Midara na Ao-chan wa Benkyou ga Dekinai</option>
-<option value='38098'>Mix: Meisei Story</option>
-<option value='38150'>Namu Amida Butsu!: Rendai Utena</option>
-<option value='38397'>Nande Koko ni Sensei ga!?</option>
-<option value='38814'>Nobunaga-sensei no Osanazuma</option>
-<option value='38707'>RobiHachi</option>
-<option value='37426'>Sarazanmai</option>
-<option value='38787'>Senryuu Shoujo</option>
-<option value='38759'>Sewayaki Kitsune no Senko-san</option>
-<option value='37952'>Shoumetsu Toshi</option>
-<option value='38004'>World Witches Series: 501-butai Hasshin Shimasu!</option>
-<option value='37940'>Yatogame-chan Kansatsu Nikki</option>
-</select>
-</div>
-<br><br>
-<div id='code_div' style='display:none'><hr><br>
-Your verification code is:<br><br><b><code><span id='code'></span></code></b><br><br>Please copy and paste this code inside the "Location" field on your MAL profile. Once this is done, click the button below to register your team.
-</div>
-<br>
-<br>
-<br>
-<button id='register_btn' style='display:none' class='btn btn-primary btn-block'>Register Team</button>
-</div> -->
-<div class='text-center'>Registration is now closed.</div>
-</div>
+
+    <h1 class='text-center' id='title'>FAL Registration</h1>
+    <br>
+    <div id='main' class='container-fluid'>
+
+        <!-- <div class='col-md-offset-3 col-md-6 col-lg-offset-4 col-lg-4 col-xl-offset-5 col-xl-2'>
+            <label>Your MAL Username:</label>
+            <input type='text' class='form-control' id='username_input' placeholder='Username'>
+            <br>
+            <button class='btn btn-info btn-block' id='code_btn'>Continue</button>
+            <br>
+            <br>
+            <div id='selections_div' style='display:none'>
+                <h3>Select your team:</h3>
+                <br>
+                <label>Active Show #1</label>
+                <br />
+                <select class='form-control' id="0">
+                    <option value='39337'>Araiya-san!: Ore to Aitsu ga Onnayu de!?</option>
+                    <option value='38860'>Bakumatsu: Crisis</option>
+                    <option value='38186'>Bokutachi wa Benkyou ga Dekinai</option>
+                    <option value='37435'>Carole & Tuesday</option>
+                    <option value='38226'>Chou Kadou Girl ⅙: Amazing Stranger</option>
+                    <option value='38731'>Diamond no Ace: Act II</option>
+                    <option value='39063'>Fairy Gone</option>
+                    <option value='37806'>Gunjou no Magmel</option>
+                    <option value='38091'>Hachigatsu no Cinderella Nine</option>
+                    <option value='38268'>Hangyakusei Million Arthur 2nd Season</option>
+                    <option value='37614'>Hitoribocchi no 笳銀雷 Seikatsu</option>
+                    <option value='38295'>Joshikausei</option>
+                    <option value='36407'>Kenja no Mago</option>
+                    <option value='38000'>Kimetsu no Yaiba</option>
+                    <option value='38080'>Kono Oto Tomare!</option>
+                    <option value='34620'>Kono Yo no Hate de Koi wo Utau Shoujo YU-NO</option>
+                    <option value='37964'>Mayonaka no Occult Koumuin</option>
+                    <option value='38778'>Midara na Ao-chan wa Benkyou ga Dekinai</option>
+                    <option value='38098'>Mix: Meisei Story</option>
+                    <option value='38150'>Namu Amida Butsu!: Rendai Utena</option>
+                    <option value='38397'>Nande Koko ni Sensei ga!?</option>
+                    <option value='38814'>Nobunaga-sensei no Osanazuma</option>
+                    <option value='38707'>RobiHachi</option>
+                    <option value='37426'>Sarazanmai</option>
+                    <option value='38787'>Senryuu Shoujo</option>
+                    <option value='38759'>Sewayaki Kitsune no Senko-san</option>
+                    <option value='37952'>Shoumetsu Toshi</option>
+                    <option value='38004'>World Witches Series: 501-butai Hasshin Shimasu!</option>
+                    <option value='37940'>Yatogame-chan Kansatsu Nikki</option>
+                </select>
+                <br />
+                <label>Active Show #2</label>
+                <br />
+                <select class='form-control' id="1">
+                    <option value='39337'>Araiya-san!: Ore to Aitsu ga Onnayu de!?</option>
+                    <option value='38860'>Bakumatsu: Crisis</option>
+                    <option value='38186'>Bokutachi wa Benkyou ga Dekinai</option>
+                    <option value='37435'>Carole & Tuesday</option>
+                    <option value='38226'>Chou Kadou Girl ⅙: Amazing Stranger</option>
+                    <option value='38731'>Diamond no Ace: Act II</option>
+                    <option value='39063'>Fairy Gone</option>
+                    <option value='37806'>Gunjou no Magmel</option>
+                    <option value='38091'>Hachigatsu no Cinderella Nine</option>
+                    <option value='38268'>Hangyakusei Million Arthur 2nd Season</option>
+                    <option value='37614'>Hitoribocchi no 笳銀雷 Seikatsu</option>
+                    <option value='38295'>Joshikausei</option>
+                    <option value='36407'>Kenja no Mago</option>
+                    <option value='38000'>Kimetsu no Yaiba</option>
+                    <option value='38080'>Kono Oto Tomare!</option>
+                    <option value='34620'>Kono Yo no Hate de Koi wo Utau Shoujo YU-NO</option>
+                    <option value='37964'>Mayonaka no Occult Koumuin</option>
+                    <option value='38778'>Midara na Ao-chan wa Benkyou ga Dekinai</option>
+                    <option value='38098'>Mix: Meisei Story</option>
+                    <option value='38150'>Namu Amida Butsu!: Rendai Utena</option>
+                    <option value='38397'>Nande Koko ni Sensei ga!?</option>
+                    <option value='38814'>Nobunaga-sensei no Osanazuma</option>
+                    <option value='38707'>RobiHachi</option>
+                    <option value='37426'>Sarazanmai</option>
+                    <option value='38787'>Senryuu Shoujo</option>
+                    <option value='38759'>Sewayaki Kitsune no Senko-san</option>
+                    <option value='37952'>Shoumetsu Toshi</option>
+                    <option value='38004'>World Witches Series: 501-butai Hasshin Shimasu!</option>
+                    <option value='37940'>Yatogame-chan Kansatsu Nikki</option>
+                </select>
+                <br />
+                <label>Active Show #3</label>
+                <br />
+                <select class='form-control' id="2">
+                    <option value='39337'>Araiya-san!: Ore to Aitsu ga Onnayu de!?</option>
+                    <option value='38860'>Bakumatsu: Crisis</option>
+                    <option value='38186'>Bokutachi wa Benkyou ga Dekinai</option>
+                    <option value='37435'>Carole & Tuesday</option>
+                    <option value='38226'>Chou Kadou Girl ⅙: Amazing Stranger</option>
+                    <option value='38731'>Diamond no Ace: Act II</option>
+                    <option value='39063'>Fairy Gone</option>
+                    <option value='37806'>Gunjou no Magmel</option>
+                    <option value='38091'>Hachigatsu no Cinderella Nine</option>
+                    <option value='38268'>Hangyakusei Million Arthur 2nd Season</option>
+                    <option value='37614'>Hitoribocchi no 笳銀雷 Seikatsu</option>
+                    <option value='38295'>Joshikausei</option>
+                    <option value='36407'>Kenja no Mago</option>
+                    <option value='38000'>Kimetsu no Yaiba</option>
+                    <option value='38080'>Kono Oto Tomare!</option>
+                    <option value='34620'>Kono Yo no Hate de Koi wo Utau Shoujo YU-NO</option>
+                    <option value='37964'>Mayonaka no Occult Koumuin</option>
+                    <option value='38778'>Midara na Ao-chan wa Benkyou ga Dekinai</option>
+                    <option value='38098'>Mix: Meisei Story</option>
+                    <option value='38150'>Namu Amida Butsu!: Rendai Utena</option>
+                    <option value='38397'>Nande Koko ni Sensei ga!?</option>
+                    <option value='38814'>Nobunaga-sensei no Osanazuma</option>
+                    <option value='38707'>RobiHachi</option>
+                    <option value='37426'>Sarazanmai</option>
+                    <option value='38787'>Senryuu Shoujo</option>
+                    <option value='38759'>Sewayaki Kitsune no Senko-san</option>
+                    <option value='37952'>Shoumetsu Toshi</option>
+                    <option value='38004'>World Witches Series: 501-butai Hasshin Shimasu!</option>
+                    <option value='37940'>Yatogame-chan Kansatsu Nikki</option>
+                </select>
+                <br />
+                <label>Active Show #4</label>
+                <br />
+                <select class='form-control' id="3">
+                    <option value='39337'>Araiya-san!: Ore to Aitsu ga Onnayu de!?</option>
+                    <option value='38860'>Bakumatsu: Crisis</option>
+                    <option value='38186'>Bokutachi wa Benkyou ga Dekinai</option>
+                    <option value='37435'>Carole & Tuesday</option>
+                    <option value='38226'>Chou Kadou Girl ⅙: Amazing Stranger</option>
+                    <option value='38731'>Diamond no Ace: Act II</option>
+                    <option value='39063'>Fairy Gone</option>
+                    <option value='37806'>Gunjou no Magmel</option>
+                    <option value='38091'>Hachigatsu no Cinderella Nine</option>
+                    <option value='38268'>Hangyakusei Million Arthur 2nd Season</option>
+                    <option value='37614'>Hitoribocchi no 笳銀雷 Seikatsu</option>
+                    <option value='38295'>Joshikausei</option>
+                    <option value='36407'>Kenja no Mago</option>
+                    <option value='38000'>Kimetsu no Yaiba</option>
+                    <option value='38080'>Kono Oto Tomare!</option>
+                    <option value='34620'>Kono Yo no Hate de Koi wo Utau Shoujo YU-NO</option>
+                    <option value='37964'>Mayonaka no Occult Koumuin</option>
+                    <option value='38778'>Midara na Ao-chan wa Benkyou ga Dekinai</option>
+                    <option value='38098'>Mix: Meisei Story</option>
+                    <option value='38150'>Namu Amida Butsu!: Rendai Utena</option>
+                    <option value='38397'>Nande Koko ni Sensei ga!?</option>
+                    <option value='38814'>Nobunaga-sensei no Osanazuma</option>
+                    <option value='38707'>RobiHachi</option>
+                    <option value='37426'>Sarazanmai</option>
+                    <option value='38787'>Senryuu Shoujo</option>
+                    <option value='38759'>Sewayaki Kitsune no Senko-san</option>
+                    <option value='37952'>Shoumetsu Toshi</option>
+                    <option value='38004'>World Witches Series: 501-butai Hasshin Shimasu!</option>
+                    <option value='37940'>Yatogame-chan Kansatsu Nikki</option>
+                </select>
+                <br />
+                <label>Active Show #5</label>
+                <br />
+                <select class='form-control' id="4">
+                    <option value='39337'>Araiya-san!: Ore to Aitsu ga Onnayu de!?</option>
+                    <option value='38860'>Bakumatsu: Crisis</option>
+                    <option value='38186'>Bokutachi wa Benkyou ga Dekinai</option>
+                    <option value='37435'>Carole & Tuesday</option>
+                    <option value='38226'>Chou Kadou Girl ⅙: Amazing Stranger</option>
+                    <option value='38731'>Diamond no Ace: Act II</option>
+                    <option value='39063'>Fairy Gone</option>
+                    <option value='37806'>Gunjou no Magmel</option>
+                    <option value='38091'>Hachigatsu no Cinderella Nine</option>
+                    <option value='38268'>Hangyakusei Million Arthur 2nd Season</option>
+                    <option value='37614'>Hitoribocchi no 笳銀雷 Seikatsu</option>
+                    <option value='38295'>Joshikausei</option>
+                    <option value='36407'>Kenja no Mago</option>
+                    <option value='38000'>Kimetsu no Yaiba</option>
+                    <option value='38080'>Kono Oto Tomare!</option>
+                    <option value='34620'>Kono Yo no Hate de Koi wo Utau Shoujo YU-NO</option>
+                    <option value='37964'>Mayonaka no Occult Koumuin</option>
+                    <option value='38778'>Midara na Ao-chan wa Benkyou ga Dekinai</option>
+                    <option value='38098'>Mix: Meisei Story</option>
+                    <option value='38150'>Namu Amida Butsu!: Rendai Utena</option>
+                    <option value='38397'>Nande Koko ni Sensei ga!?</option>
+                    <option value='38814'>Nobunaga-sensei no Osanazuma</option>
+                    <option value='38707'>RobiHachi</option>
+                    <option value='37426'>Sarazanmai</option>
+                    <option value='38787'>Senryuu Shoujo</option>
+                    <option value='38759'>Sewayaki Kitsune no Senko-san</option>
+                    <option value='37952'>Shoumetsu Toshi</option>
+                    <option value='38004'>World Witches Series: 501-butai Hasshin Shimasu!</option>
+                    <option value='37940'>Yatogame-chan Kansatsu Nikki</option>
+                </select>
+                <br>
+                <br>
+                <label>Bench Show #1</label>
+                <br />
+                <select class='form-control' id="5">
+                    <option value='39337'>Araiya-san!: Ore to Aitsu ga Onnayu de!?</option>
+                    <option value='38860'>Bakumatsu: Crisis</option>
+                    <option value='38186'>Bokutachi wa Benkyou ga Dekinai</option>
+                    <option value='37435'>Carole & Tuesday</option>
+                    <option value='38226'>Chou Kadou Girl ⅙: Amazing Stranger</option>
+                    <option value='38731'>Diamond no Ace: Act II</option>
+                    <option value='39063'>Fairy Gone</option>
+                    <option value='37806'>Gunjou no Magmel</option>
+                    <option value='38091'>Hachigatsu no Cinderella Nine</option>
+                    <option value='38268'>Hangyakusei Million Arthur 2nd Season</option>
+                    <option value='37614'>Hitoribocchi no 笳銀雷 Seikatsu</option>
+                    <option value='38295'>Joshikausei</option>
+                    <option value='36407'>Kenja no Mago</option>
+                    <option value='38000'>Kimetsu no Yaiba</option>
+                    <option value='38080'>Kono Oto Tomare!</option>
+                    <option value='34620'>Kono Yo no Hate de Koi wo Utau Shoujo YU-NO</option>
+                    <option value='37964'>Mayonaka no Occult Koumuin</option>
+                    <option value='38778'>Midara na Ao-chan wa Benkyou ga Dekinai</option>
+                    <option value='38098'>Mix: Meisei Story</option>
+                    <option value='38150'>Namu Amida Butsu!: Rendai Utena</option>
+                    <option value='38397'>Nande Koko ni Sensei ga!?</option>
+                    <option value='38814'>Nobunaga-sensei no Osanazuma</option>
+                    <option value='38707'>RobiHachi</option>
+                    <option value='37426'>Sarazanmai</option>
+                    <option value='38787'>Senryuu Shoujo</option>
+                    <option value='38759'>Sewayaki Kitsune no Senko-san</option>
+                    <option value='37952'>Shoumetsu Toshi</option>
+                    <option value='38004'>World Witches Series: 501-butai Hasshin Shimasu!</option>
+                    <option value='37940'>Yatogame-chan Kansatsu Nikki</option>
+                </select>
+                <br />
+                <label>Bench Show #2</label>
+                <br />
+                <select class='form-control' id="6">
+                    <option value='39337'>Araiya-san!: Ore to Aitsu ga Onnayu de!?</option>
+                    <option value='38860'>Bakumatsu: Crisis</option>
+                    <option value='38186'>Bokutachi wa Benkyou ga Dekinai</option>
+                    <option value='37435'>Carole & Tuesday</option>
+                    <option value='38226'>Chou Kadou Girl ⅙: Amazing Stranger</option>
+                    <option value='38731'>Diamond no Ace: Act II</option>
+                    <option value='39063'>Fairy Gone</option>
+                    <option value='37806'>Gunjou no Magmel</option>
+                    <option value='38091'>Hachigatsu no Cinderella Nine</option>
+                    <option value='38268'>Hangyakusei Million Arthur 2nd Season</option>
+                    <option value='37614'>Hitoribocchi no 笳銀雷 Seikatsu</option>
+                    <option value='38295'>Joshikausei</option>
+                    <option value='36407'>Kenja no Mago</option>
+                    <option value='38000'>Kimetsu no Yaiba</option>
+                    <option value='38080'>Kono Oto Tomare!</option>
+                    <option value='34620'>Kono Yo no Hate de Koi wo Utau Shoujo YU-NO</option>
+                    <option value='37964'>Mayonaka no Occult Koumuin</option>
+                    <option value='38778'>Midara na Ao-chan wa Benkyou ga Dekinai</option>
+                    <option value='38098'>Mix: Meisei Story</option>
+                    <option value='38150'>Namu Amida Butsu!: Rendai Utena</option>
+                    <option value='38397'>Nande Koko ni Sensei ga!?</option>
+                    <option value='38814'>Nobunaga-sensei no Osanazuma</option>
+                    <option value='38707'>RobiHachi</option>
+                    <option value='37426'>Sarazanmai</option>
+                    <option value='38787'>Senryuu Shoujo</option>
+                    <option value='38759'>Sewayaki Kitsune no Senko-san</option>
+                    <option value='37952'>Shoumetsu Toshi</option>
+                    <option value='38004'>World Witches Series: 501-butai Hasshin Shimasu!</option>
+                    <option value='37940'>Yatogame-chan Kansatsu Nikki</option>
+                </select>
+            </div>
+            <br>
+            <br>
+            <div id='code_div' style='display:none'>
+                <hr>
+                <br> Your verification code is:
+                <br>
+                <br><b><code><span id='code'></span></code></b>
+                <br>
+                <br>Please copy and paste this code inside the "Location" field on your MAL profile. Once this is done, click the button below to register your team.
+            </div>
+            <br>
+            <br>
+            <br>
+            <button id='register_btn' style='display:none' class='btn btn-primary btn-block'>Register Team</button>
+        </div> -->
+        <div class='text-center'>Registration is now closed.</div>
+    </div>
 </body>
+
 </html>

--- a/index.php
+++ b/index.php
@@ -301,7 +301,7 @@ session_start();
             <button class='btn btn-info btn-block' id='team_code_btn'>Continue</button>
             <br>
             <br>
-            <div id='instructions_div'>
+            <div id='instructions_div' style='display:none'>
                 <hr>
                 <br> Your verification code is:
                 <br>
@@ -311,7 +311,17 @@ session_start();
                 <br><br>
                 <button class='btn btn-primary btn-block' id='team_btn'>See Team</button>
             </div>
-            <div id='team_div'></div>
+            <div id='team_div' style='display:none'>
+                <h3>Active Team:</h3>
+                <h4 id='team_1'>1</h4>
+                <h4 id='team_2'>2</h4>
+                <h4 id='team_3'>3</h4>
+                <h4 id='team_4'>4</h4>
+                <h4 id='team_5'>5</h4>
+                <h3>Bench Team:</h3>
+                <h4 id='team_6'>6</h4>
+                <h4 id='team_7'>7</h4>
+            </div>
         </div>
     </div>
 </body>

--- a/index.php
+++ b/index.php
@@ -25,7 +25,7 @@ session_start();
     <div id='main' class='container-fluid'>
 
         <div class='col-md-offset-3 col-md-6 col-lg-offset-4 col-lg-4 col-xl-offset-5 col-xl-2'>
-            <label>Your MAL Username:</label>
+            <!-- <label>Your MAL Username:</label>
             <input type='text' class='form-control' id='username_input' placeholder='Username'>
             <br>
             <button class='btn btn-info btn-block' id='code_btn'>Continue</button>
@@ -286,7 +286,7 @@ session_start();
             <br>
             <br>
             <br>
-            <button id='register_btn' style='display:none' class='btn btn-primary btn-block'>Register Team</button>
+            <button id='register_btn' style='display:none' class='btn btn-primary btn-block'>Register Team</button> -->
 
             <div class='text-center'>Registration is now closed.</div>
             <br>

--- a/index.php
+++ b/index.php
@@ -24,7 +24,7 @@ session_start();
     <br>
     <div id='main' class='container-fluid'>
 
-        <!-- <div class='col-md-offset-3 col-md-6 col-lg-offset-4 col-lg-4 col-xl-offset-5 col-xl-2'>
+        <div class='col-md-offset-3 col-md-6 col-lg-offset-4 col-lg-4 col-xl-offset-5 col-xl-2'>
             <label>Your MAL Username:</label>
             <input type='text' class='form-control' id='username_input' placeholder='Username'>
             <br>
@@ -287,8 +287,32 @@ session_start();
             <br>
             <br>
             <button id='register_btn' style='display:none' class='btn btn-primary btn-block'>Register Team</button>
-        </div> -->
-        <div class='text-center'>Registration is now closed.</div>
+
+            <div class='text-center'>Registration is now closed.</div>
+            <br>
+            <br>
+            <br>
+
+            <h2 class='text-center' id='subtitle'>Check Your Team</h2>
+            <br>
+            <label>Your MAL Username:</label>
+            <input type='text' class='form-control' id='team_username_input' placeholder='Username'>
+            <br>
+            <button class='btn btn-info btn-block' id='team_code_btn'>Continue</button>
+            <br>
+            <br>
+            <div id='instructions_div'>
+                <hr>
+                <br> Your verification code is:
+                <br>
+                <br><b><code><span id='team_code'></span></code></b>
+                <br>
+                <br>Please copy and paste this code inside the "Location" field on your MAL profile. Once this is done, click the button below to see your team.
+                <br><br>
+                <button class='btn btn-primary btn-block' id='team_btn'>See Team</button>
+            </div>
+            <div id='team_div'></div>
+        </div>
     </div>
 </body>
 

--- a/info.php
+++ b/info.php
@@ -1,0 +1,3 @@
+<?php
+	phpinfo();
+?>

--- a/info.php
+++ b/info.php
@@ -1,3 +1,0 @@
-<?php
-	phpinfo();
-?>

--- a/reg.js
+++ b/reg.js
@@ -58,10 +58,10 @@ $(document).ready(function(){
     	});
 		 })
 	$('#team_code_btn').click(function () {
-		document.getElementById("username_input").disabled = true;
-		document.getElementById("code_btn").disabled = true;
+		document.getElementById("team_username_input").disabled = true;
+		document.getElementById("team_code_btn").disabled = true;
 
-		username = document.getElementById('username_input').value.toLowerCase();
+		username = document.getElementById('team_username_input').value.toLowerCase();
 		if (username == '') {
 			alert('Username cannot be blank.');
 			return;
@@ -71,16 +71,34 @@ $(document).ready(function(){
 			success: function (response) {
 				if (response == 'username invalid') {
 					alert('Username invalid. Please try again.');
-					document.getElementById("username_input").disabled = false;
-					document.getElementById("code_btn").disabled = false;
+					document.getElementById("team_username_input").disabled = false;
+					document.getElementById("team_code_btn").disabled = false;
 					return;
 				}
-				document.getElementById('code').innerHTML = response;
-				document.getElementById('code_div').style.display = 'block';
-				document.getElementById('register_btn').style.display = 'block';
-				document.getElementById('selections_div').style.display = 'block';
+				document.getElementById('team_code').innerHTML = response;
+				document.getElementById('instructions_div').style.display = 'block';
 			}
 		})
+	})
+	$('#team_btn').click(function () {
+		document.getElementById('team_btn').disabled = true;
+
+		$.ajax({
+			url: 'reg.php?func=get_team&username=' + username,
+			success: function (response) {
+				if (response == 'auth invalid') {
+					alert('Could not validate your username. Please verify that the code was copied correctly.');
+					document.getElementById('team_btn').disabled = false;
+				}
+				else {
+					var ids = response.trim().split(/\s+/);
+					ids.forEach(function (id, index) {
+						document.getElementById('team_' + (index + 1)).innerHTML = show_dict[id];
+					});
+					document.getElementById('team_div').style.display = 'block';
+				}
+			}
+		});
 	})
 });
 /*

--- a/reg.js
+++ b/reg.js
@@ -90,6 +90,10 @@ $(document).ready(function(){
 					alert('Could not validate your username. Please verify that the code was copied correctly.');
 					document.getElementById('team_btn').disabled = false;
 				}
+				else if (response == 'user not found') {
+					alert("You have not registered for Fantasy Anime League. You don't have a team.");
+					document.getElementById('team_btn').disabled = false;
+				}
 				else {
 					var ids = response.trim().split(/\s+/);
 					ids.forEach(function (id, index) {

--- a/reg.js
+++ b/reg.js
@@ -56,7 +56,32 @@ $(document).ready(function(){
 				document.getElementById('register_btn').disabled = false;
 			}
     	});
-   	})
+		 })
+	$('#team_code_btn').click(function () {
+		document.getElementById("username_input").disabled = true;
+		document.getElementById("code_btn").disabled = true;
+
+		username = document.getElementById('username_input').value.toLowerCase();
+		if (username == '') {
+			alert('Username cannot be blank.');
+			return;
+		}
+		$.ajax({
+			url: "reg.php?func=get_code&username=" + username,
+			success: function (response) {
+				if (response == 'username invalid') {
+					alert('Username invalid. Please try again.');
+					document.getElementById("username_input").disabled = false;
+					document.getElementById("code_btn").disabled = false;
+					return;
+				}
+				document.getElementById('code').innerHTML = response;
+				document.getElementById('code_div').style.display = 'block';
+				document.getElementById('register_btn').style.display = 'block';
+				document.getElementById('selections_div').style.display = 'block';
+			}
+		})
+	})
 });
 /*
 window.onload = function(){

--- a/reg.php
+++ b/reg.php
@@ -74,7 +74,12 @@
 			//valid otherwise
 			$filename = '../../fal_data/'.$_SESSION['username'].'.txt';
 			$team_info = file_get_contents($filename);
-			echo $team_info;
+			if ($team_info === false) {
+				echo 'user not found';
+			}
+			else {
+				echo $team_info;
+			}
 		}
 		else{
 			echo 'auth invalid';

--- a/reg.php
+++ b/reg.php
@@ -67,4 +67,18 @@
 			echo 'auth invalid';
 		}
 	}
+	if($_GET['func'] == 'get_team' && isset($_GET['username']) && $_GET['username'] != ''){
+		$url = 'https://myanimelist.net/profile/'.$_SESSION['username'];
+		$usr_page = file_get_contents($url);
+		if (strpos($usr_page, '<span class="user-status-data di-ib fl-r">'.$_SESSION['code']) !== false){
+			//valid otherwise
+			$filename = '../../fal_data/'.$_SESSION['username'].'.txt';
+			$team_info = file_get_contents($filename);
+			echo $team_info;
+		}
+		else{
+			echo 'auth invalid';
+		}
+		return;
+	}
 ?>


### PR DESCRIPTION
Fixes #1

Right now this code is in the regtest directory on the server, so you can test this out at http://mfal.website/regtest

Since you guys didn't register for FAL, if you want to test this you need to make a file in `fal_data/` with the filename being the username you're testing with and the contents being 7 id's of the current season's anime. Otherwise, you'll get an error saying you haven't registered.

[Here are some screenshots of how it looks during each step when you're checking your team.](https://imgur.com/a/Kuzq9hO)

When this is merged in, I'll copy the updated source files to the reg directory on the server.